### PR TITLE
[Feat] 상단 캘린더 터치로 날짜 이동 기능 구현

### DIFF
--- a/YAP/YAP/Source/Feature/MainUI/CalendarScrollView.swift
+++ b/YAP/YAP/Source/Feature/MainUI/CalendarScrollView.swift
@@ -31,12 +31,19 @@ struct CalendarScrollView: View {
                 .font(.caption)
                 .foregroundColor(.gray)
               
-              Text(dates[index].day)
-                .font(.headline)
-                .foregroundColor(index == selectedIndex ? .white : .black)
-                .frame(width: itemWidth, height: 36)
-                .background(index == selectedIndex ? Color.blue : Color.clear)
-                .clipShape(Circle())
+              Button {
+                selectedIndex = index
+                selectedDate = dates[index]
+                scrollOffset = -CGFloat(index) * totalItemWidth
+                dragOffset = 0
+              } label: {
+                Text(dates[index].day)
+                  .font(.headline)
+                  .foregroundColor(index == selectedIndex ? .white : .black)
+                  .frame(width: itemWidth, height: 36)
+                  .background(index == selectedIndex ? Color.blue : Color.clear)
+                  .clipShape(Circle())
+              }
             }
           }
         }


### PR DESCRIPTION
## 🔍 PR Content
<!-- 작업 내용 설명 -->
달력 상의 날짜를 누르면 해당 날짜로 이동하는 기능을 구현합니다.

## 📸 Screenshot
<!-- 작업 화면의 스크린샷 -->

https://github.com/user-attachments/assets/e0463602-1c7f-40f6-bad7-029193f8126e


## 📍 PR Point 
<!-- 질문하고 싶은 내용 혹은 공유하고 싶은 코드 내용을 작성 -->
Text를 Button으로 바꿨습니다.

## 🗑️ Resolved
<!-- 연결 할 이슈를 입력해주세요. ex) #1 -->
